### PR TITLE
refactor: drop telegram bot library, move to axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,14 +11,13 @@
   "author": "Jani Luukko <jjluukko@cs.helsinki.fi>",
   "license": "MIT",
   "dependencies": {
+    "axios": "^0.21.1",
     "date-fns": "^2.6.0",
     "dotenv": "^2.0.0",
     "knex": "^0.21.0",
     "moment": "^2.14.1",
-    "node-telegram-bot-api": "^0.40.0",
     "pg": "^8.0.2",
-    "ramda": "^0.22.1",
-    "request-promise": "^4.2.2"
+    "ramda": "^0.22.1"
   },
   "devDependencies": {
     "eslint": "^4.18.2",

--- a/src/services/FoodlistService.js
+++ b/src/services/FoodlistService.js
@@ -1,7 +1,7 @@
-const request = require('request-promise')
 const fi = require('date-fns/locale/fi')
 const { format } = require('date-fns')
 const R = require('ramda')
+const axios = require('axios')
 
 const restaurants = {
   chemicum: 10,
@@ -13,6 +13,7 @@ const restaurants = {
 function parseFoodlistData({ data, information }) {
   const now = new Date()
   const unicafeFormat = format(now, 'EEEEEE dd.MM', { locale: fi })
+
   const foodList = R.pipe(
     R.filter(({ date }) => date.toLowerCase() === unicafeFormat),
     R.chain(({ data }) => data),
@@ -30,6 +31,7 @@ function parseFoodlistData({ data, information }) {
       warnings: meta['1'],
     }))
   )(data)
+
   return {
     restaurantName: information.restaurant,
     foodList,
@@ -43,10 +45,9 @@ function parseFoodlistData({ data, information }) {
  */
 function fetchRestaurantFoodlist(restaurant) {
   if (!restaurants[restaurant]) return Promise.reject('No restaurant found')
-  return request
+  return axios
     .get('http://messi.hyyravintolat.fi/publicapi/restaurant/' + restaurants[restaurant])
-    .then(JSON.parse)
-    .then(parseFoodlistData)
+    .then(({ data }) => parseFoodlistData(data))
 }
 
 module.exports = fetchRestaurantFoodlist

--- a/src/services/telegramService.js
+++ b/src/services/telegramService.js
@@ -1,0 +1,14 @@
+const axios = require('axios')
+
+const sendMessage = (chatId, message, disableWebPagePreview) =>
+  axios
+    .post(`https://api.telegram.org/bot${process.env.API_TOKEN}/sendMessage`, {
+      chat_id: chatId,
+      text: message,
+      parse_mode: 'Markdown',
+      disable_web_page_preview: disableWebPagePreview,
+    })
+    .then(_ => console.log('message sent'))
+    .catch(error => console.error(error))
+
+module.exports = { sendMessage }


### PR DESCRIPTION
There's no need for the complete telegram bot library because we only send messages. Drop node-telegram-bot-api dependency.

The request-promise library has been deprecated, use axios instead.

Closing #12 